### PR TITLE
chore: prepare release 0.119.12

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -271,7 +271,6 @@ jobs:
         run: |
           gh release create v${{ needs.release_checks.outputs.image_tag }} \
             --title v${{ needs.release_checks.outputs.image_tag }} \
-            --latest=false \
             --generate-notes \
             --notes-start-tag ${{ env.PREVIOUS_TAG }}
       - name: Tag Go packages on GitHub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## v0.119.12
+- Updates non-opentelemetry dependencies to latest possible version
+- Sets metrics scope name to `github.com/solarwinds/solarwinds-otel-collector-releases`
+
 ## v0.119.11
 - Fix CVE-2025-27144: Uncontrolled Resource Consumption
 

--- a/cmd/solarwinds-otel-collector/go.mod
+++ b/cmd/solarwinds-otel-collector/go.mod
@@ -161,12 +161,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector-releases/exporter/solarwindsexporter v0.119.11
-	github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarwindsextension v0.119.11
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.11
-	github.com/solarwinds/solarwinds-otel-collector-releases/processor/k8seventgenerationprocessor v0.119.11
-	github.com/solarwinds/solarwinds-otel-collector-releases/receiver/swohostmetricsreceiver v0.119.11
-	github.com/solarwinds/solarwinds-otel-collector-releases/receiver/swok8sobjectsreceiver v0.119.11
+	github.com/solarwinds/solarwinds-otel-collector-releases/exporter/solarwindsexporter v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarwindsextension v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/processor/k8seventgenerationprocessor v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/receiver/swohostmetricsreceiver v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/receiver/swok8sobjectsreceiver v0.119.12
 	github.com/spf13/cobra v1.9.1
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/confmap v1.26.0
@@ -585,8 +585,8 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/snowflakedb/gosnowflake v1.12.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-releases/internal/k8sconfig v0.119.11 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.11 // indirect
+	github.com/solarwinds/solarwinds-otel-collector-releases/internal/k8sconfig v0.119.12 // indirect
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.12 // indirect
 	github.com/solarwindscloud/apm-proto v1.0.8 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/exporter/solarwindsexporter/go.mod
+++ b/exporter/solarwindsexporter/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector-releases/exporter/solarwi
 go 1.24.2
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarwindsextension v0.119.11
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.11
+	github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarwindsextension v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.12
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0
@@ -42,7 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.11 // indirect
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector/client v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.119.0 // indirect

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarw
 go 1.24.2
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.11
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.11
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 require (
 	github.com/mdelapenya/tlscert v0.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.11
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.36.0
 	go.opentelemetry.io/collector/pdata v1.25.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.119.11"
+const Version = "0.119.12"

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/shirou/gopsutil/v3 v3.24.5
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.11
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.11
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12
 	github.com/stretchr/testify v1.10.0
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.opentelemetry.io/collector/component v0.119.0

--- a/receiver/swok8sobjectsreceiver/go.mod
+++ b/receiver/swok8sobjectsreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.119.0
-	github.com/solarwinds/solarwinds-otel-collector-releases/internal/k8sconfig v0.119.11
+	github.com/solarwinds/solarwinds-otel-collector-releases/internal/k8sconfig v0.119.12
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0


### PR DESCRIPTION
#### Description
Prepares release v0.119.12.
Also provides tiny fix on propagation of 'latest' GH release. Previously, `latest=false` was explicitly set, thus no GH release had a chance to become latest. Omitting it completely will defer to default GH behavior utilizing timestamp, which should be suffictient.

<!-- Issue number if applicable
**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-releases/issues/XXXX
-->

#### Testing
Build pipeline should be sufficient.
