### PR TITLE
chore: excluded solarwinds-otel-collector-releases from dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -42,6 +42,7 @@ updates:
           - "*"
         exclude-patterns:
           - "*opentelemetry*"
+          - "*solarwinds-otel-collector-releases*"
       collector-opentelemetry:
         patterns:
           - "*opentelemetry*"
@@ -51,6 +52,7 @@ updates:
           - "*"
         exclude-patterns:
           - "*opentelemetry*"
+          - "*solarwinds-otel-collector-releases*"
         update-types:
           - "patch"
           - "minor"
@@ -76,6 +78,7 @@ updates:
           - "*"
         exclude-patterns:
           - "*opentelemetry*"
+          - "*solarwinds-otel-collector-releases*"
       components-opentelemetry:
         patterns:
           - "*opentelemetry*"
@@ -85,6 +88,7 @@ updates:
           - "*"
         exclude-patterns:
           - "*opentelemetry*"
+          - "*solarwinds-otel-collector-releases*"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
#### Description
When updating versions, dependabot puts in wrong versions for solarwinds-otel-collector-releases that we have to manually update.  But the versions are updated anyway when releasing, so we do not even have to use dependabot for them, therefore, I am excluding them.

Every section with patern "*" was given extra exclude pattern "*solarwinds-otel-collector-releases*"
Release process will be responsible for raising these versions.