### PR TITLE
chore: preparing for release v0.123.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+## v0.123.0
+- Consumes OpenTelemetry Collector dependencies v0.123.0.
+- SolarWinds exporter is no reported as otlp/solarwinds-<name> in collector's telemetry.
+
 ## v0.119.12
 - Updates non-opentelemetry dependencies to latest possible version
 - Sets metrics scope name to `github.com/solarwinds/solarwinds-otel-collector-releases`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v0.123.0
 - Consumes OpenTelemetry Collector dependencies v0.123.0.
-- SolarWinds exporter is no reported as otlp/solarwinds-<name> in collector's telemetry.
+- SolarWinds exporter is now reported as otlp/solarwinds-<name> in collector's telemetry.
 
 ## v0.119.12
 - Updates non-opentelemetry dependencies to latest possible version

--- a/cmd/solarwinds-otel-collector/go.mod
+++ b/cmd/solarwinds-otel-collector/go.mod
@@ -161,13 +161,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.123.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.123.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.123.0
-	github.com/solarwinds/solarwinds-otel-collector-releases/connector/solarwindsentityconnector v0.119.12
-	github.com/solarwinds/solarwinds-otel-collector-releases/exporter/solarwindsexporter v0.119.12
-	github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarwindsextension v0.119.12
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12
-	github.com/solarwinds/solarwinds-otel-collector-releases/processor/k8seventgenerationprocessor v0.119.12
-	github.com/solarwinds/solarwinds-otel-collector-releases/receiver/swohostmetricsreceiver v0.119.12
-	github.com/solarwinds/solarwinds-otel-collector-releases/receiver/swok8sobjectsreceiver v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/connector/solarwindsentityconnector v0.123.0
+	github.com/solarwinds/solarwinds-otel-collector-releases/exporter/solarwindsexporter v0.123.0
+	github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarwindsextension v0.123.0
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.123.0
+	github.com/solarwinds/solarwinds-otel-collector-releases/processor/k8seventgenerationprocessor v0.123.0
+	github.com/solarwinds/solarwinds-otel-collector-releases/receiver/swohostmetricsreceiver v0.123.0
+	github.com/solarwinds/solarwinds-otel-collector-releases/receiver/swok8sobjectsreceiver v0.123.0
 	github.com/spf13/cobra v1.9.1
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/confmap v1.29.0
@@ -609,8 +609,8 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/snowflakedb/gosnowflake v1.12.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-releases/internal/k8sconfig v0.119.12 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.12 // indirect
+	github.com/solarwinds/solarwinds-otel-collector-releases/internal/k8sconfig v0.123.0 // indirect
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.123.0 // indirect
 	github.com/solarwindscloud/apm-proto v1.0.8 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect

--- a/exporter/solarwindsexporter/go.mod
+++ b/exporter/solarwindsexporter/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector-releases/exporter/solarwi
 go 1.24.2
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarwindsextension v0.119.12
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarwindsextension v0.123.0
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/component/componenttest v0.123.0
@@ -42,7 +42,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12 // indirect
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.123.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector v0.123.0 // indirect
 	go.opentelemetry.io/collector/client v1.29.0 // indirect

--- a/extension/solarwindsextension/go.mod
+++ b/extension/solarwindsextension/go.mod
@@ -3,8 +3,8 @@ module github.com/solarwinds/solarwinds-otel-collector-releases/extension/solarw
 go 1.24.2
 
 require (
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.12
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.123.0
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/component/componenttest v0.123.0

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 require (
 	github.com/mdelapenya/tlscert v0.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.123.0
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.123.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.36.0
 	go.opentelemetry.io/collector/pdata v1.29.0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.119.12"
+const Version = "0.123.0"

--- a/receiver/swohostmetricsreceiver/go.mod
+++ b/receiver/swohostmetricsreceiver/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/shirou/gopsutil/v3 v3.24.5
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.119.12
-	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/testutil v0.123.0
+	github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version v0.123.0
 	github.com/stretchr/testify v1.10.0
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.opentelemetry.io/collector/component v1.29.0

--- a/receiver/swok8sobjectsreceiver/go.mod
+++ b/receiver/swok8sobjectsreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.123.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.123.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/xk8stest v0.123.0
-	github.com/solarwinds/solarwinds-otel-collector-releases/internal/k8sconfig v0.119.12
+	github.com/solarwinds/solarwinds-otel-collector-releases/internal/k8sconfig v0.123.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v1.29.0
 	go.opentelemetry.io/collector/component/componenttest v0.123.0


### PR DESCRIPTION
#### Description
Prepares release of v0.123.0

Includes fix for running `solarwinds` exporter. Exporter is now reported in collector internal telemetry as `otlp/solarwinds` exporter. 

#### Testing
By CI/CD pipeline.
