### PR TITLE
ci: revert to use more complex version fetch

### DIFF
--- a/.github/actions/dockerScoutScan/action.yml
+++ b/.github/actions/dockerScoutScan/action.yml
@@ -18,17 +18,17 @@ inputs:
     description: Image name to compare to
     required: true
   compare-to-tag:
-    description: Tag to compare to, required if `compare-to-suffix` is not provided, if both provided, this is prioritized
+    description: Tag to compare to, required if `compare-to-regex` is not provided, if both provided, this is prioritized
     required: false
-  compare-to-suffix:
-    description: Suffix identifying the image in the registry to compare to, required if `compare-to` is not provided
+  compare-to-regex:
+    description: Regex to find latest image in the registry to compare to, required if `compare-to` is not provided
     required: false
 
 runs:
   using: composite
   steps:
-    - name: Ensure `compare-to-tag` or `compare-to-suffix` is provided
-      if: ${{ !inputs.compare-to-tag && !inputs.compare-to-suffix }}
+    - name: Ensure `compare-to-tag` or `compare-to-regex` is provided
+      if: ${{ !inputs.compare-to-tag && !inputs.compare-to-regex }}
       shell: bash
       run: exit 1
 
@@ -39,10 +39,10 @@ runs:
         password: ${{ inputs.token }}
 
     - name: Get latest tag
-      if: ${{ inputs.compare-to-suffix }}
+      if: ${{ inputs.compare-to-regex }}
       id: get-latest
       shell: bash
-      run: echo "tag=$(sed -n 's/.*const Version = \"\([^\"]*\)\".*/\1/p' ./pkg/version/version.go)${{ inputs.compare-to-suffix }}" >> $GITHUB_OUTPUT
+      run: echo "tag=$(curl -s 'https://registry.hub.docker.com/v2/repositories/solarwinds/solarwinds-otel-collector/tags/' | jq -r '.results[].name' | grep -E '${{ inputs.compare-to-regex }}' | sort -r | head -n 1)" >> $GITHUB_OUTPUT
 
     - name: Docker scout
       id: docker-scout

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -103,7 +103,7 @@ jobs:
           current-image: solarwinds-otel-collector
           current-tag: ${{ needs.generate_tag.outputs.tag }}-nanoserver-ltsc2019
           compare-to-image: ${{ env.DOCKERHUB_IMAGE }}
-          compare-to-suffix: '-nanoserver-ltsc2019'
+          compare-to-regex: '^[0-9]+\.[0-9]+\.[0-9]+-nanoserver-ltsc2019$'
 
       - name: Docker scout image scan for Windows 2022
         uses: ./.github/actions/dockerScoutScan
@@ -113,7 +113,7 @@ jobs:
           current-image: solarwinds-otel-collector
           current-tag: ${{ needs.generate_tag.outputs.tag }}-nanoserver-ltsc2022
           compare-to-image: ${{ env.DOCKERHUB_IMAGE }}
-          compare-to-suffix: '-nanoserver-ltsc2022'
+          compare-to-regex: '^[0-9]+\.[0-9]+\.[0-9]+-nanoserver-ltsc2022$'
 
       - name: Save image
         run: |
@@ -148,7 +148,7 @@ jobs:
           current-image: solarwinds-otel-collector
           current-tag: ${{ needs.generate_tag.outputs.tag }}-k8s
           compare-to-image: ${{ env.DOCKERHUB_IMAGE }}
-          compare-to-suffix: '-k8s'
+          compare-to-regex: '[0-9]+\.[0-9]+\.[0-9]+-k8s$'
 
   build_windows_k8s:
     runs-on: windows-2022
@@ -183,7 +183,7 @@ jobs:
           current-image: solarwinds-otel-collector
           current-tag: ${{ needs.generate_tag.outputs.tag }}-nanoserver-ltsc2019-k8s
           compare-to-image: ${{ env.DOCKERHUB_IMAGE }}
-          compare-to-suffix: '-nanoserver-ltsc2019-k8s'
+          compare-to-regex: '^[0-9]+\.[0-9]+\.[0-9]+-nanoserver-ltsc2019-k8s$'
 
       - name: Docker scout image scan for Windows 2022
         uses: ./.github/actions/dockerScoutScan
@@ -193,7 +193,7 @@ jobs:
           current-image: solarwinds-otel-collector
           current-tag: ${{ needs.generate_tag.outputs.tag }}-nanoserver-ltsc2022-k8s
           compare-to-image: ${{ env.DOCKERHUB_IMAGE }}
-          compare-to-suffix: '-nanoserver-ltsc2022-k8s'
+          compare-to-regex: '^[0-9]+\.[0-9]+\.[0-9]+-nanoserver-ltsc2022-k8s$'
             
       - name: Save image
         run: |

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -148,7 +148,7 @@ jobs:
           current-image: solarwinds-otel-collector
           current-tag: ${{ needs.generate_tag.outputs.tag }}-k8s
           compare-to-image: ${{ env.DOCKERHUB_IMAGE }}
-          compare-to-regex: '[0-9]+\.[0-9]+\.[0-9]+-k8s$'
+          compare-to-regex: '^[0-9]+\.[0-9]+\.[0-9]+-k8s$'
 
   build_windows_k8s:
     runs-on: windows-2022


### PR DESCRIPTION
#### Description
Revert of https://github.com/solarwinds/solarwinds-otel-collector-releases/pull/123/files. Could not be done via GH revert action as some changes to some stuff changed already were made.

<!-- Issue number if applicable
**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-releases/issues/XXXX
-->

#### Testing
E2E pipeline.
