### PR TITLE
chore: prepare release 0.127.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## vNext
 
+## v0.127.1
+- Consumes [solarwinds-otel-collector-contrib](https://github.com/solarwinds/solarwinds-otel-collector-contrib) `v0.127.1` dependencies - [full changelog](https://github.com/solarwinds/solarwinds-otel-collector-contrib/blob/main/CHANGELOG.md#v01271)
+
 ## v0.127.0
 - Consumes OpenTelemetry Collector dependencies v0.127.0.
 - Release process utilizes builder to build the various distributions.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 include Makefile.Common
 
-# Define compatible builder_version with the current version of the collector
-builder_version := 0.127.0
+# Define compatible otel_version with the current version of the collector
 contrib_version := 0.127.0
 
 ALL_SRC := $(shell find . \( -name "*.go" \) \
@@ -29,9 +28,9 @@ check-licenses:
 
 .PHONY: prepare-release
 prepare-release:
-	@build/prepare-release.sh $(version) $(builder_version) $(contrib_version)
+	@build/prepare-release.sh $(version) $(otel_version)
 
 .PHONY: build
 build:
-	go install go.opentelemetry.io/collector/cmd/builder@v$(builder_version)
+	go install go.opentelemetry.io/collector/cmd/builder@v$(otel_version)
 	CGO_ENABLED=0 GOEXPERIMENT=boringcrypto builder --config=./distributions/$(distribution)/manifest.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Makefile.Common
 
 # Define compatible otel_version with the current version of the collector
-contrib_version := 0.127.0
+otel_version := 0.127.0
 
 ALL_SRC := $(shell find . \( -name "*.go" \) \
 							-not -path '*generated*' \

--- a/build/prepare-release.sh
+++ b/build/prepare-release.sh
@@ -14,13 +14,12 @@
 # limitations under the License.
 
 if [ "$#" -lt 1 ]; then
-    echo "Usage: $0 <version> $1 <builder_version> $2 <contrib_version>"
+    echo "Usage: $0 <version> $1 <otel_version>"
     exit 1
 fi
 
 VERSION=$1
-BUILDER_VERSION=$2
-CONTRIB_VERSION=$3
+OTEL_VERSION=$2
 
 # Update CHANGELOG.md
 CHANGELOG_FILE="./CHANGELOG.md"
@@ -43,8 +42,8 @@ for f in $ALL_MANIFEST_YAML; do
     echo "Updated version in distribution yaml \`$f\` with version v$VERSION"
 done
 
-if [ -z "$CONTRIB_VERSION" ]; then
-  echo "CONTRIB_VERSION not set, skipping."
+if [ -z "$OTEL_VERSION" ]; then
+  echo "OTEL_VERSION not set, skipping."
 else
   # update swi_contrib_version in Makefile
     MAKEFILE="./Makefile"
@@ -52,36 +51,27 @@ else
         echo "Makefile not found!"
         exit 1
     fi
-    perl -pi -e "s|contrib_version := \d+\.\d+\.\d+|contrib_version := $CONTRIB_VERSION|g" "$MAKEFILE"
-    echo "Updated contrib_version in Makefile to version $CONTRIB_VERSION"
+    perl -pi -e "s|otel_version := \d+\.\d+\.\d+|otel_version := $OTEL_VERSION|g" "$MAKEFILE"
+    echo "Updated otel_version in Makefile to version $OTEL_VERSION"
 
-  # update solarwinds contrib references in distribution yaml files
+  # update otel contrib references in distribution yaml files
   for f in $ALL_MANIFEST_YAML; do
-      perl -pi -e "s|^(\s+- gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/[^ ]*) v[0-9]+\.[0-9]+\.[0-9]+$|\1 v$CONTRIB_VERSION|" "$f"
-      echo "References to 'github.com/solarwinds/solarwinds-otel-collector-contrib' in $f updated with version v$CONTRIB_VERSION"
-      perl -pi -e "s|^(\s+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/[^ ]*) v[0-9]+\.[0-9]+\.[0-9]+$|\1 v$CONTRIB_VERSION|" "$f"
-      echo "References to 'github.com/open-telemetry/opentelemetry-collector-contrib' in $f updated with version v$CONTRIB_VERSION"
-      perl -pi -e "s|^(\s+- gomod: go.opentelemetry.io/[^ ]*) v[0-9]+\.[0-9]+\.[0-9]+$|\1 v$CONTRIB_VERSION|" "$f"
-      echo "References to 'go.opentelemetry.io' in $f updated with version v$CONTRIB_VERSION"
+      perl -pi -e "s|^(\s+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/[^ ]*) v[0-9]+\.[0-9]+\.[0-9]+$|\1 v$OTEL_VERSION|" "$f"
+      echo "References to 'github.com/open-telemetry/opentelemetry-collector-contrib' in $f updated with version v$OTEL_VERSION"
+      perl -pi -e "s|^(\s+- gomod: go.opentelemetry.io/[^ ]*) v[0-9]+\.[0-9]+\.[0-9]+$|\1 v$OTEL_VERSION|" "$f"
+      echo "References to 'go.opentelemetry.io' in $f updated with version v$OTEL_VERSION"
   done
-
-  # We need to run go mod tidy after raising versions of solarwinds-otel-collector-contrib components
-  echo "Running go mod tidy"
-  find . -name "go.mod" -execdir sh -c 'go mod tidy' \;
 fi
 
-if [ -z "$BUILDER_VERSION" ]; then
-  echo "BUILDER_VERSION not set, skipping."
-else
-  # update builder_version in Makefile
-  MAKEFILE="./Makefile"
-  if [ ! -f "$MAKEFILE" ]; then
-      echo "Makefile not found!"
-      exit 1
-  fi
-  perl -pi -e "s|builder_version := \d+\.\d+\.\d+|builder_version := $BUILDER_VERSION|g" "$MAKEFILE"
-  echo "Updated builder_version in Makefile to version $BUILDER_VERSION"
-fi
+# update solarwinds contrib references in distribution yaml files
+for f in $ALL_MANIFEST_YAML; do
+    perl -pi -e "s|^(\s+- gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/[^ ]*) v[0-9]+\.[0-9]+\.[0-9]+$|\1 v$VERSION|" "$f"
+    echo "References to 'github.com/solarwinds/solarwinds-otel-collector-contrib' in $f updated with version v$VERSION"
+done
+
+# We need to run go mod tidy after raising versions of solarwinds-otel-collector-contrib components
+echo "Running go mod tidy"
+find . -name "go.mod" -execdir sh -c 'go mod tidy' \;
 
 # update pkg\version\version.go to set the actual release version
 GO_VERSION_FILE="./pkg/version/version.go"

--- a/distributions/k8s/manifest.yaml
+++ b/distributions/k8s/manifest.yaml
@@ -2,21 +2,21 @@ dist:
   module: github.com/solarwinds/solarwinds-otel-collector/k8s
   name: solarwinds-otel-collector-k8s
   description: SolarWinds OpenTelemetry Collector for Kubernetes
-  version: 0.127.0
+  version: 0.127.1
   output_path: ./_build
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.127.1
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.127.0
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.127.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/exporter/solarwindsexporter v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/exporter/solarwindsexporter v0.127.1
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.127.0
@@ -34,8 +34,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/k8seventgenerationprocessor v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sworkloadtypeprocessor v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/k8seventgenerationprocessor v0.127.1
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sworkloadtypeprocessor v0.127.1
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.127.0
@@ -46,12 +46,12 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swok8sobjectsreceiver v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swok8sobjectsreceiver v0.127.1
 
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/connector/solarwindsentityconnector v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/connector/solarwindsentityconnector v0.127.1
 
 replaces:
   # k8sattributesprocessor@v0.127.0 is not compatible with v0.33.1

--- a/distributions/playground/manifest.yaml
+++ b/distributions/playground/manifest.yaml
@@ -2,7 +2,7 @@ dist:
   module: github.com/solarwinds/solarwinds-otel-collector/playground
   name: solarwinds-otel-collector-playground
   description: SolarWinds OpenTelemetry Collector - Playground
-  version: 0.127.0
+  version: 0.127.1
   output_path: ./_build
 
 extensions:
@@ -25,14 +25,14 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sigv4authextension v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.127.1
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.127.0
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.127.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/exporter/solarwindsexporter v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/exporter/solarwindsexporter v0.127.1
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.127.0
@@ -63,8 +63,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/sumologicprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/k8seventgenerationprocessor v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sworkloadtypeprocessor v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/k8seventgenerationprocessor v0.127.1
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sworkloadtypeprocessor v0.127.1
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.127.0
@@ -166,8 +166,8 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swohostmetricsreceiver v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swok8sobjectsreceiver v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swohostmetricsreceiver v0.127.1
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swok8sobjectsreceiver v0.127.1
 
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.127.0
@@ -182,7 +182,7 @@ connectors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/sumconnector v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/connector/solarwindsentityconnector v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/connector/solarwindsentityconnector v0.127.1
 
 replaces:
   # k8sattributesprocessor@v0.127.0 is not compatible with v0.33.1

--- a/distributions/verified/manifest.yaml
+++ b/distributions/verified/manifest.yaml
@@ -2,7 +2,7 @@ dist:
   module: github.com/solarwinds/solarwinds-otel-collector/verified
   name: solarwinds-otel-collector-verified
   description: SolarWinds OpenTelemetry Collector - Verified
-  version: 0.127.0
+  version: 0.127.1
   output_path: ./_build
 
 extensions:
@@ -11,14 +11,14 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/solarwindsapmsettingsextension v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/extension/solarwindsextension v0.127.1
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.127.0
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.127.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/exporter/solarwindsexporter v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/exporter/solarwindsexporter v0.127.1
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.127.0
@@ -36,8 +36,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/k8seventgenerationprocessor v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sworkloadtypeprocessor v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/k8seventgenerationprocessor v0.127.1
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/processor/swok8sworkloadtypeprocessor v0.127.1
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.127.0
@@ -64,13 +64,13 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swohostmetricsreceiver v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swok8sobjectsreceiver v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swohostmetricsreceiver v0.127.1
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/receiver/swok8sobjectsreceiver v0.127.1
 
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.127.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.127.0
-  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/connector/solarwindsentityconnector v0.127.0
+  - gomod: github.com/solarwinds/solarwinds-otel-collector-contrib/connector/solarwindsentityconnector v0.127.1
 
 replaces:
   # k8sattributesprocessor@v0.127.0 is not compatible with v0.33.1

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -51,11 +51,10 @@ To release a new version of SolarWinds OpenTelemetry Collector:
 2. Run
 
     ```shell
-    make prepare-release version=0.123.7 builder_version=0.123.0 contrib_version=0.123.7
+    make prepare-release version=0.123.7 otel_version=0.123.0
     ```
     Replace versions accordingly.
     `version` (mandatory) - the actual release version. Updates CHANGELOG.md, [version.go](/pkg/version/version.go) and versions in distribution yaml files.
-    `builder_version` (optional) - updates version of [builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) used in Makefile
-    `contrib_version` (optional) - updates versions of packages from [solarwinds-otel-collector-contrib](https://github.com/solarwinds/solarwinds-otel-collector-contrib/releases), [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases) and [go.opentelemetry.io](https://go.opentelemetry.io) in distribution yaml files.
+    `otel_version` (optional) - updates version of [builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) used in Makefile and versions of packages from [solarwinds-otel-collector-contrib](https://github.com/solarwinds/solarwinds-otel-collector-contrib/releases), [opentelemetry-collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases) and [go.opentelemetry.io](https://go.opentelemetry.io) in distribution yaml files.
 3. Verify the generated changes, prepare a PR and merge it.
 4. This will trigger a build pipeline that will release a new version of the collector.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-const Version = "0.127.0"
+const Version = "0.127.1"


### PR DESCRIPTION
#### Description
Prepares release v0.127.1. Also updates prepare-release script to handle swotelcol and otelcol contrib dependencies separately; simplified to use single otel version.

To review changes separately:
- update of the script: https://github.com/solarwinds/solarwinds-otel-collector-releases/commit/f097fea6fb71b2600927d046c6b83b959ba4baa8
- release: https://github.com/solarwinds/solarwinds-otel-collector-releases/commit/06ed528bbc6ebcaa42082b6d7439130fb1a9b1bc

#### Testing
Green pipeline
