### PR TITLE
chore: updated e2e tests

### DIFF
--- a/internal/e2e/testdata/emitting_collector.yaml
+++ b/internal/e2e/testdata/emitting_collector.yaml
@@ -3,13 +3,16 @@ service:
   pipelines:
     metrics:
       receivers: [otlp]
-      exporters: [solarwinds]
+      processors: [solarwinds]
+      exporters: [otlp]
     traces:
       receivers: [otlp]
-      exporters: [solarwinds]
+      processors: [solarwinds]
+      exporters: [otlp]
     logs:
       receivers: [otlp]
-      exporters: [solarwinds]
+      processors: [solarwinds]
+      exporters: [otlp]
 
 receivers:
   otlp:
@@ -17,13 +20,21 @@ receivers:
       grpc:
         endpoint: :17016
 
+processors:
+  solarwinds:
+    extension: solarwinds
+
 extensions:
   solarwinds:
-    token: <no-matter-in-test>
     collector_name: "testing_collector_name"
-    endpoint_url_override: receiver:17016
+    grpc: &grpc_settings
+      endpoint: receiver:17016
+      tls:
+        insecure: false
+      headers: { "Authorization": "Bearer no-matter-in-test" }
     resource:
       custom_attribute: "custom_attribute_value"
 
 exporters:
-  solarwinds:
+  otlp:
+    <<: *grpc_settings

--- a/internal/e2e/testdata/emitting_collector_without_entity.yaml
+++ b/internal/e2e/testdata/emitting_collector_without_entity.yaml
@@ -3,13 +3,16 @@ service:
   pipelines:
     metrics:
       receivers: [otlp]
-      exporters: [solarwinds]
+      processors: [solarwinds]
+      exporters: [otlp]
     traces:
       receivers: [otlp]
-      exporters: [solarwinds]
+      processors: [solarwinds]
+      exporters: [otlp]
     logs:
       receivers: [otlp]
-      exporters: [solarwinds]
+      processors: [solarwinds]
+      exporters: [otlp]
 
 receivers:
   otlp:
@@ -17,12 +20,20 @@ receivers:
       grpc:
         endpoint: :17016
 
+processors:
+  solarwinds:
+    extension: solarwinds
+
 extensions:
   solarwinds:
-    token: <no-matter-in-test>
     collector_name: "testing_collector_name"
-    endpoint_url_override: receiver:17016
+    grpc: &grpc_settings
+      endpoint: receiver:17016
+      tls:
+        insecure: false
+      headers: { "Authorization": "Bearer no-matter-in-test" }
     without_entity: true
 
 exporters:
-  solarwinds:
+  otlp:
+    <<: *grpc_settings

--- a/internal/e2e/testdata/swohostmetricsreceiver.yaml
+++ b/internal/e2e/testdata/swohostmetricsreceiver.yaml
@@ -3,7 +3,12 @@ service:
   pipelines:
     metrics:
       receivers: [swohostmetrics]
-      exporters: [solarwinds]
+      processors: [solarwinds]
+      exporters: [otlp]
+
+processors:
+  solarwinds:
+    extension: solarwinds
 
 receivers:
   # Following setup contains only some of implemented functionality.
@@ -25,9 +30,12 @@ receivers:
 
 extensions:
   solarwinds:
-    token: <no-matter-in-test>
     collector_name: "testing_collector_name"
-    endpoint_url_override: receiver:17016
-
+    grpc: &grpc_settings
+      endpoint: receiver:17016
+      tls:
+        insecure: false
+      headers: { "Authorization": "Bearer no-matter-in-test" }
 exporters:
-  solarwinds:
+  otlp:
+    <<: *grpc_settings

--- a/internal/e2e/testdata/swohostmetricsreceiver_default.yaml
+++ b/internal/e2e/testdata/swohostmetricsreceiver_default.yaml
@@ -3,7 +3,12 @@ service:
   pipelines:
     metrics:
       receivers: [swohostmetrics]
-      exporters: [solarwinds]
+      processors: [solarwinds]
+      exporters: [otlp]
+
+processors:
+  solarwinds:
+    extension: solarwinds
 
 receivers:
   # Following setup contains only some of implemented functionality.
@@ -23,11 +28,15 @@ receivers:
 
 extensions:
   solarwinds:
-    token: <no-matter-in-test>
     collector_name: "testing_collector_name"
-    endpoint_url_override: receiver:17016
+    grpc: &grpc_settings
+      endpoint: receiver:17016
+      tls:
+        insecure: false
+      headers: { "Authorization": "Bearer no-matter-in-test" }
 
 exporters:
-  solarwinds:
+  otlp:
+    <<: *grpc_settings
   debug:
     verbosity: detailed


### PR DESCRIPTION
#### Description
Tests updated to use new otlp exporter and solarwinds processor.

Devtested against latest published docker image
![image](https://github.com/user-attachments/assets/db783f34-e439-485f-b2b9-5a39ef840c49)
