### PR TITLE
chore: Add dependency review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,39 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable
+# packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: 'Dependency review'
+on:
+  pull_request:
+    branches: [ "main"]
+
+# If using a dependency submission action in this workflow this permission will need to be set to:
+#
+# permissions:
+#   contents: write
+#
+# https://docs.github.com/en/enterprise-cloud@latest/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api
+permissions:
+  contents: read
+  # Write permissions for pull-requests are required for using the `comment-summary-in-pr` option, comment out if you aren't using this option
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
+        with:
+          comment-summary-in-pr: always
+          fail-on-severity: moderate
+        #   deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
+        #   retry-on-snapshot-warnings: true


### PR DESCRIPTION
#### Description
The file was mostly pre-generated by GitHub. The changes compared to origin file can be seen in commits in https://github.com/solarwinds/solarwinds-otel-collector-contrib/pull/79.

Dependency review is tool from GHAS to show changes in dependencies (what new we are adding/removing,...) that generates comment (overriden on new push). The vulnerabilities should be listed in Github database https://github.com/advisories.

We can whitelist some option if there it is known issue we want to skip (allow-ghsas).

Later on, we can enumerate what licenses we do not what to introduce (deny-licenses) or whitelist only those we want to use (allow-licenses). The options are mutually exclusive.

More info here: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-the-dependency-review-action



<!-- Issue number if applicable
**Tracking Issue:** https://github.com/solarwinds/solarwinds-otel-collector-releases/issues/XXXX
-->

#### Testing
No tests added.