### PR TITLE
chore: bump Go version from 1.25.8 to 1.25.9

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ on:
       - 'release/**'
 
 env:
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.9'
 
 jobs:
   checks:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.25.8"
+          go-version: "^1.25.9"
 
       # for npx commands (CircleCI MCP may need this)
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.25.8'
+  GO_VERSION: '1.25.9'
   DOCKERHUB_IMAGE: solarwinds/solarwinds-otel-collector
 
 jobs:

--- a/cmd/changes-analyzer/go.mod
+++ b/cmd/changes-analyzer/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-releases/changes-analyzer
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0

--- a/pkg/version/go.mod
+++ b/pkg/version/go.mod
@@ -1,3 +1,3 @@
 module github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version
 
-go 1.25.8
+go 1.25.9


### PR DESCRIPTION
#### Description
Bump Go version from 1.25.8 to 1.25.9

