### PR TITLE
chore: Bump OTel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## vNext
-- Bumps OpenTelemetry packages from v0.145.0 to v0.150.0
+- Updates OpenTelemetry modules to [v1.56.0/v0.150.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.150.0)
 
 ## v0.145.10
 - Consumes public solarwinds-otel-collector-contrib v0.145.10 dependencies - [full changelog](https://github.com/solarwinds/solarwinds-otel-collector-contrib/blob/main/CHANGELOG.md#v014510)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## vNext
+- Bumps OpenTelemetry packages from v0.145.0 to v0.150.0
 
 ## v0.145.10
 - Consumes public solarwinds-otel-collector-contrib v0.145.10 dependencies - [full changelog](https://github.com/solarwinds/solarwinds-otel-collector-contrib/blob/main/CHANGELOG.md#v014510)

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ include submodules/solarwinds-otel-collector-core/build/Makefile.Release
 include submodules/solarwinds-otel-collector-core/build/Makefile.Licenses
 
 # Define compatible otel_version with the current version of the collector
-otel_version := 0.145.0
+otel_version := 0.150.0

--- a/docs/playground-components.md
+++ b/docs/playground-components.md
@@ -90,7 +90,6 @@ All components. Generated based on manifest file
 | Exporter | [prometheusremotewriteexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter) | No |
 | Exporter | [pulsarexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/pulsarexporter) | No |
 | Exporter | [rabbitmqexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/rabbitmqexporter) | No |
-| Exporter | [sapmexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sapmexporter) | No |
 | Exporter | [sematextexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sematextexporter) | No |
 | Exporter | [sentryexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sentryexporter) | No |
 | Exporter | [signalfxexporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/signalfxexporter) | No |
@@ -130,7 +129,6 @@ All components. Generated based on manifest file
 | Processor | [tailsamplingprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor) | No |
 | Processor | [transformprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor) | No |
 | Processor | [unrollprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/unrollprocessor) | No |
-| Processor | [datadogsemanticsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/datadogsemanticsprocessor) | No |
 | Processor | [dnslookupprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/dnslookupprocessor) | No |
 | Processor | [isolationforestprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/isolationforestprocessor) | No |
 | Processor | [metricstarttimeprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricstarttimeprocessor) | No |
@@ -158,7 +156,6 @@ All components. Generated based on manifest file
 | Receiver | [azureblobreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureblobreceiver) | No |
 | Receiver | [azureeventhubreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureeventhubreceiver) | No |
 | Receiver | [azuremonitorreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azuremonitorreceiver) | No |
-| Receiver | [bigipreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/bigipreceiver) | No |
 | Receiver | [carbonreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/carbonreceiver) | No |
 | Receiver | [chronyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/chronyreceiver) | No |
 | Receiver | [ciscoosreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/ciscoosreceiver) | No |
@@ -249,7 +246,6 @@ All components. Generated based on manifest file
 | Receiver | [faroreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/faroreceiver) | No |
 | Receiver | [gitlabreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/gitlabreceiver) | No |
 | Receiver | [huaweicloudcesreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/huaweicloudcesreceiver) | No |
-| Receiver | [k8slogreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8slogreceiver) | No |
 | Receiver | [libhoneyreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/libhoneyreceiver) | No |
 | Receiver | [netflowreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/netflowreceiver) | No |
 | Receiver | [pprofreceiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/pprofreceiver) | No |

--- a/examples/integrations/apache/config.yaml
+++ b/examples/integrations/apache/config.yaml
@@ -137,7 +137,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -162,7 +162,7 @@ service:
         - batch
         - solarwinds/apache
       exporters:
-        - otlp
+        - otlp_grpc
         
     # Optional pipeline
     # logs/apache:

--- a/examples/integrations/apm/config.yaml
+++ b/examples/integrations/apm/config.yaml
@@ -26,7 +26,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -41,7 +41,7 @@ service:
         - batch
         - solarwinds/otlp
       exporters:
-        - otlp
+        - otlp_grpc
     metrics/otlp:
       receivers:
         - otlp
@@ -50,7 +50,7 @@ service:
         - batch
         - solarwinds/otlp
       exporters:
-        - otlp
+        - otlp_grpc
     logs/otlp:
       receivers:
         - otlp
@@ -59,4 +59,4 @@ service:
         - batch
         - solarwinds/otlp
       exporters:
-        - otlp
+        - otlp_grpc

--- a/examples/integrations/confluentcloud/config.yaml
+++ b/examples/integrations/confluentcloud/config.yaml
@@ -61,7 +61,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -80,5 +80,5 @@ service:
         - batch
         - solarwinds/confluentcloud
       exporters:
-        - otlp
+        - otlp_grpc
 

--- a/examples/integrations/docker/config.yaml
+++ b/examples/integrations/docker/config.yaml
@@ -85,7 +85,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -104,7 +104,7 @@ service:
         - batch
         - solarwinds/docker
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/docker:

--- a/examples/integrations/elasticsearch/config.yaml
+++ b/examples/integrations/elasticsearch/config.yaml
@@ -234,7 +234,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -257,7 +257,7 @@ service:
         - batch
         - solarwinds/elasticsearch
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/elasticsearch:

--- a/examples/integrations/filelog/config.yaml
+++ b/examples/integrations/filelog/config.yaml
@@ -58,7 +58,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -78,4 +78,4 @@ service:
         - batch
         - solarwinds/filelog
       exporters:
-        - otlp
+        - otlp_grpc

--- a/examples/integrations/host/config.yaml
+++ b/examples/integrations/host/config.yaml
@@ -436,7 +436,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -468,7 +468,7 @@ service:
         - batch
         - solarwinds/host
       exporters:
-        - otlp
+        - otlp_grpc
 
 #     Optional pipeline for ingesting logs
 #     logs/host:

--- a/examples/integrations/iis/config.yaml
+++ b/examples/integrations/iis/config.yaml
@@ -112,7 +112,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -135,7 +135,7 @@ service:
         - batch
         - solarwinds/iis
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/iis:

--- a/examples/integrations/kafka/config.yaml
+++ b/examples/integrations/kafka/config.yaml
@@ -175,7 +175,7 @@ extensions:
 
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -197,7 +197,7 @@ service:
         - batch
         - solarwinds/kafka
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/kafka:

--- a/examples/integrations/memcached/config.yaml
+++ b/examples/integrations/memcached/config.yaml
@@ -108,7 +108,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -131,7 +131,7 @@ service:
         - batch
         - solarwinds/memcached
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/memcached:

--- a/examples/integrations/mongodb/config.yaml
+++ b/examples/integrations/mongodb/config.yaml
@@ -161,7 +161,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "dbo solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -180,7 +180,7 @@ service:
         - batch
         - solarwinds/mongodb
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/mongodb:

--- a/examples/integrations/mysql/config.yaml
+++ b/examples/integrations/mysql/config.yaml
@@ -138,7 +138,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "dbo solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -157,7 +157,7 @@ service:
         - batch
         - solarwinds/mysql
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/mysql:

--- a/examples/integrations/nginx/config.yaml
+++ b/examples/integrations/nginx/config.yaml
@@ -138,7 +138,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -166,7 +166,7 @@ service:
         - batch
         - solarwinds/nginx
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/nginx:

--- a/examples/integrations/oracledb/config.yaml
+++ b/examples/integrations/oracledb/config.yaml
@@ -109,7 +109,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "dbo solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -128,7 +128,7 @@ service:
         - batch
         - solarwinds/oracledb
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/oracledb:

--- a/examples/integrations/otlp/config.yaml
+++ b/examples/integrations/otlp/config.yaml
@@ -52,7 +52,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -71,4 +71,4 @@ service:
         - batch
         - solarwinds/otlp
       exporters:
-        - otlp
+        - otlp_grpc

--- a/examples/integrations/postgresql/config.yaml
+++ b/examples/integrations/postgresql/config.yaml
@@ -124,7 +124,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "dbo solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -143,7 +143,7 @@ service:
         - batch
         - solarwinds/postgresql
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/postgresql:

--- a/examples/integrations/prometheus/config.yaml
+++ b/examples/integrations/prometheus/config.yaml
@@ -50,7 +50,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -69,4 +69,4 @@ service:
         - batch
         - solarwinds/prometheus
       exporters:
-        - otlp
+        - otlp_grpc

--- a/examples/integrations/rabbitmq/config.yaml
+++ b/examples/integrations/rabbitmq/config.yaml
@@ -73,7 +73,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -93,7 +93,7 @@ service:
         - batch
         - solarwinds/rabbitmq
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/rabbitmq:

--- a/examples/integrations/redis/config.yaml
+++ b/examples/integrations/redis/config.yaml
@@ -113,7 +113,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "dbo solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -132,7 +132,7 @@ service:
         - batch
         - solarwinds/redis
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/redis:

--- a/examples/integrations/snowflake/config.yaml
+++ b/examples/integrations/snowflake/config.yaml
@@ -123,7 +123,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -142,4 +142,4 @@ service:
         - batch
         - solarwinds/snowflake
       exporters:
-        - otlp
+        - otlp_grpc

--- a/examples/integrations/sqlserver/config.yaml
+++ b/examples/integrations/sqlserver/config.yaml
@@ -115,7 +115,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "dbo solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -134,7 +134,7 @@ service:
         - batch
         - solarwinds/sqlserver
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/sqlserver:

--- a/examples/integrations/zookeeper/config.yaml
+++ b/examples/integrations/zookeeper/config.yaml
@@ -127,7 +127,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -153,7 +153,7 @@ service:
         - batch
         - solarwinds/zookeeper
       exporters:
-        - otlp
+        - otlp_grpc
 
     # Optional pipeline
     # logs/zookeeper:


### PR DESCRIPTION
#### Description
Prepares release v0.150.0, along with OTel bumps (core v1.51.0 → v1.56.0, contrib v0.145.0 → v0.150.0). Removes 4 components deleted upstream (`sapmexporter`, `datadogsemanticsprocessor`, `bigipreceiver`, `k8slogreceiver`) from playground distribution.

#### Testing
CI/CD pipeline, sanity e2e testing of new collector.