### PR TITLE
docs: add nop receiver integration example

### DIFF
--- a/examples/integrations/nop/README.md
+++ b/examples/integrations/nop/README.md
@@ -1,0 +1,6 @@
+# Nop Integration Example
+
+This directory contains an example configuration using the `nop` receiver.
+This configuration is compatible with SolarWinds Observability SaaS.
+
+- `config.yaml`: Example configuration file for the nop receiver.

--- a/examples/integrations/nop/config.yaml
+++ b/examples/integrations/nop/config.yaml
@@ -1,0 +1,25 @@
+receivers:
+  nop:
+
+extensions:
+  solarwinds:
+    collector_name: # Required parameter
+    grpc: &grpc_settings
+      endpoint: # Required parameter
+      tls:
+        insecure: false
+      headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
+
+exporters:
+  otlp:
+    <<: *grpc_settings
+
+service:
+  extensions:
+    - solarwinds
+  pipelines:
+    metrics:
+      receivers:
+        - nop
+      exporters:
+        - otlp

--- a/examples/integrations/nop/config.yaml
+++ b/examples/integrations/nop/config.yaml
@@ -11,7 +11,7 @@ extensions:
       headers: {"Authorization": "Bearer ${env:SOLARWINDS_TOKEN}", "swi-reporter": "otel solarwinds-otel-collector"}
 
 exporters:
-  otlp:
+  otlp_grpc:
     <<: *grpc_settings
 
 service:
@@ -22,4 +22,4 @@ service:
       receivers:
         - nop
       exporters:
-        - otlp
+        - otlp_grpc


### PR DESCRIPTION
#### Description
Add a minimal config example for the `nop` receiver, following the same structure as other integration examples.

#### Testing
No functional changes — documentation/example only.

---

### Contribution Checklist

- [x] **CHANGELOG updated** - N/A (example only)
- [x] **Build verified** - N/A (example only)
- [ ] **Distribution manifests updated** - N/A
- [ ] **Public release coordination** - N/A