### PR TITLE
docs: disable telemetry metrics port in nop config to prevent port conflicts

### DIFF
--- a/examples/integrations/nop/config.yaml
+++ b/examples/integrations/nop/config.yaml
@@ -17,6 +17,11 @@ exporters:
 service:
   extensions:
     - solarwinds
+  telemetry:
+    metrics:
+      # Disable the default metrics endpoint (port 8888) to avoid port conflicts
+      # when running multiple collectors on the same host.
+      level: none
   pipelines:
     metrics:
       receivers:


### PR DESCRIPTION
## Problem

When multiple SolarWinds OTel Collectors run on the same host, the second (and subsequent) collectors fail to start because the default telemetry metrics server tries to bind `0.0.0.0:8888`, which is already in use by the first collector.

## Fix

Add `service.telemetry.metrics.level: none` to `examples/integrations/nop/config.yaml` to disable the internal metrics endpoint binding.
