### PR TITLE
chore: bump Go to 1.25.11

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ on:
       - 'release/**'
 
 env:
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
 
 jobs:
   checks:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.25.10"
+          go-version: "^1.25.11"
 
       # for npx commands (CircleCI MCP may need this)
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.25.10'
+  GO_VERSION: '1.25.11'
   DOCKERHUB_IMAGE: solarwinds/solarwinds-otel-collector
 
 jobs:

--- a/cmd/changes-analyzer/go.mod
+++ b/cmd/changes-analyzer/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-releases/changes-analyzer
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0

--- a/pkg/version/go.mod
+++ b/pkg/version/go.mod
@@ -1,3 +1,3 @@
 module github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version
 
-go 1.25.10
+go 1.25.11


### PR DESCRIPTION
#### Description
Bump Go version from 1.25.10 to 1.25.11.

#### Testing
CI only.
