### PR TITLE
chore: bump Go to 1.26.4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ on:
       - 'release/**'
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.26.4'
 
 jobs:
   checks:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "^1.25.11"
+          go-version: "^1.26.4"
 
       # for npx commands (CircleCI MCP may need this)
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: '1.25.11'
+  GO_VERSION: '1.26.4'
   DOCKERHUB_IMAGE: solarwinds/solarwinds-otel-collector
 
 jobs:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "submodules/solarwinds-otel-collector-core"]
 	path = submodules/solarwinds-otel-collector-core
 	url = https://github.com/solarwinds/solarwinds-otel-collector-core
-	branch = agents/go-1.26.4-bump

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "submodules/solarwinds-otel-collector-core"]
 	path = submodules/solarwinds-otel-collector-core
 	url = https://github.com/solarwinds/solarwinds-otel-collector-core
+	branch = agents/go-1.26.4-bump

--- a/cmd/changes-analyzer/analyzer.go
+++ b/cmd/changes-analyzer/analyzer.go
@@ -19,14 +19,15 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/PuerkitoBio/goquery"
-	"github.com/hashicorp/go-version"
 	"io"
 	"net/http"
 	"os"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/hashicorp/go-version"
 )
 
 var client = &http.Client{}
@@ -46,8 +47,8 @@ func parseVersion(verStr string) (*version.Version, error) {
 // parseLinkHeader extracts pagination URLs from the GitHub API Link header.
 func parseLinkHeader(header string) map[string]string {
 	links := make(map[string]string)
-	parts := strings.Split(header, ",")
-	for _, part := range parts {
+	parts := strings.SplitSeq(header, ",")
+	for part := range parts {
 		sections := strings.Split(part, ";")
 		if len(sections) < 2 {
 			continue

--- a/cmd/changes-analyzer/analyzer_test.go
+++ b/cmd/changes-analyzer/analyzer_test.go
@@ -18,7 +18,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -176,7 +175,7 @@ func TestGetComponentsFromGoMod(t *testing.T) {
 				// For "file not found", use a nonexistent path
 				goModPath = "/nonexistent/path/to/go.mod"
 			} else {
-				tmpFile, err := ioutil.TempFile("", "test-gomod-*.mod")
+				tmpFile, err := os.CreateTemp("", "test-gomod-*.mod")
 				if err != nil {
 					t.Fatalf("failed to create temp file: %v", err)
 				}

--- a/cmd/changes-analyzer/go.mod
+++ b/cmd/changes-analyzer/go.mod
@@ -1,6 +1,6 @@
 module github.com/solarwinds/solarwinds-otel-collector-releases/changes-analyzer
 
-go 1.25.11
+go 1.26.4
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0

--- a/pkg/version/go.mod
+++ b/pkg/version/go.mod
@@ -1,3 +1,3 @@
 module github.com/solarwinds/solarwinds-otel-collector-releases/pkg/version
 
-go 1.25.11
+go 1.26.4


### PR DESCRIPTION
Update the go.mod toolchain directive(s), the GitHub Actions copilot-setup-steps go-version pin, the CircleCI cimg/go executor image, and the build/docker golang base image where applicable to **1.26.4**.

