### PR TITLE
chore: fix use of otlp/otlp_grpc exporter

### DIFF
--- a/examples/integrations/apache/config.yaml
+++ b/examples/integrations/apache/config.yaml
@@ -177,4 +177,4 @@ service:
     #     - batch
     #     - solarwinds/apache
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/docker/config.yaml
+++ b/examples/integrations/docker/config.yaml
@@ -119,4 +119,4 @@ service:
     #     - batch
     #     - solarwinds/docker 
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/elasticsearch/config.yaml
+++ b/examples/integrations/elasticsearch/config.yaml
@@ -272,4 +272,4 @@ service:
     #     - batch
     #     - solarwinds/elasticsearch
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/host/config.yaml
+++ b/examples/integrations/host/config.yaml
@@ -488,7 +488,7 @@ service:
 #         - batch
 #         - solarwinds/host
 #       exporters:
-#         - otlp
+#         - otlp_grpc
 
 #     Optional pipeline for ingesting windows service statuses (works only on Windows machine)
 #     windowsservice/host:
@@ -497,4 +497,4 @@ service:
 #       processors:
 #         - attributes/windowsservice
 #       exporters:
-#         - otlp
+#         - otlp_grpc

--- a/examples/integrations/iis/config.yaml
+++ b/examples/integrations/iis/config.yaml
@@ -150,4 +150,4 @@ service:
     #     - batch
     #     - solarwinds/iis
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/kafka/config.yaml
+++ b/examples/integrations/kafka/config.yaml
@@ -212,4 +212,4 @@ service:
     #     - batch
     #     - solarwinds/kafka
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/memcached/config.yaml
+++ b/examples/integrations/memcached/config.yaml
@@ -146,4 +146,4 @@ service:
     #     - batch
     #     - solarwinds/memcached
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/mongodb/config.yaml
+++ b/examples/integrations/mongodb/config.yaml
@@ -195,4 +195,4 @@ service:
     #     - batch
     #     - solarwinds/mongodb
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/mysql/config.yaml
+++ b/examples/integrations/mysql/config.yaml
@@ -172,4 +172,4 @@ service:
     #     - batch
     #     - solarwinds/mysql
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/nginx/config.yaml
+++ b/examples/integrations/nginx/config.yaml
@@ -181,4 +181,4 @@ service:
     #     - batch
     #     - solarwinds/nginx
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/oracledb/config.yaml
+++ b/examples/integrations/oracledb/config.yaml
@@ -143,4 +143,4 @@ service:
     #     - batch
     #     - solarwinds/oracledb
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/postgresql/config.yaml
+++ b/examples/integrations/postgresql/config.yaml
@@ -158,4 +158,4 @@ service:
     #     - batch
     #     - solarwinds/postgresql
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/rabbitmq/config.yaml
+++ b/examples/integrations/rabbitmq/config.yaml
@@ -108,4 +108,4 @@ service:
     #     - batch
     #     - solarwinds/rabbitmq
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/redis/config.yaml
+++ b/examples/integrations/redis/config.yaml
@@ -147,4 +147,4 @@ service:
     #     - batch
     #     - solarwinds/redis
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/sqlserver/config.yaml
+++ b/examples/integrations/sqlserver/config.yaml
@@ -149,4 +149,4 @@ service:
     #     - batch
     #     - solarwinds/sqlserver
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc

--- a/examples/integrations/zookeeper/config.yaml
+++ b/examples/integrations/zookeeper/config.yaml
@@ -168,4 +168,4 @@ service:
     #     - batch
     #     - solarwinds/zookeeper
     #   exporters:
-    #     - otlp
+    #     - otlp_grpc


### PR DESCRIPTION
#### Description
Fixes commented out sections to use proper `otlp_grpc` exporter declaration.