### PR TITLE
chore: bump OpenTelemetry packages to v0.157.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## vNext
+- Bumped OpenTelemetry packages to v0.157.0 (core v1.63.0 / contrib v0.157.0)
+- Removed `exporter/googlesecopsexporter` from `playground` distribution (removed upstream in v0.154.0)
+- Removed `receiver/jmxreceiver` from `playground` distribution (removed upstream in v0.157.0)
 
 ## v0.152.6
 - Consumes public solarwinds-otel-collector-contrib v0.152.6 dependencies - [full changelog](https://github.com/solarwinds/solarwinds-otel-collector-contrib/blob/main/CHANGELOG.md#v01526)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 
 ## vNext
-- Bumped OpenTelemetry packages to v0.157.0 (core v1.63.0 / contrib v0.157.0)
-- Removed `exporter/googlesecopsexporter` from `playground` distribution (removed upstream in v0.154.0)
-- Removed `receiver/jmxreceiver` from `playground` distribution (removed upstream in v0.157.0)
+- Updates OpenTelemetry modules to [v1.63.0/v0.157.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.157.0)
 
 ## v0.152.6
 - Consumes public solarwinds-otel-collector-contrib v0.152.6 dependencies - [full changelog](https://github.com/solarwinds/solarwinds-otel-collector-contrib/blob/main/CHANGELOG.md#v01526)

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ include submodules/solarwinds-otel-collector-core/build/Makefile.Release
 include submodules/solarwinds-otel-collector-core/build/Makefile.Licenses
 
 # Define compatible otel_version with the current version of the collector
-otel_version := 0.152.0
+otel_version := 0.157.0

--- a/examples/integrations/apache/config.yaml
+++ b/examples/integrations/apache/config.yaml
@@ -28,7 +28,7 @@ receivers:
       apache.workers:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -63,7 +63,7 @@ processors:
     override: false
     system:
       hostname_sources: ["os"]
-  metricstransform/apache:
+  metrics_transform/apache:
     transforms:
       - include: apache.requests
         action: insert
@@ -153,7 +153,7 @@ service:
         - resource_detection/azure
         - resource_detection/gcp
         - resource_detection/system
-        - metricstransform/apache
+        - metrics_transform/apache
         - cumulative_to_delta/apache
         - deltatorate/apache
         - metricsgeneration/apache
@@ -167,7 +167,7 @@ service:
     # Optional pipeline
     # logs/apache:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/apache/config.yaml
+++ b/examples/integrations/apache/config.yaml
@@ -45,19 +45,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "apache"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -81,7 +81,7 @@ processors:
             label: state
             label_value: busy
         new_name: apache.workers.idle
-  cumulativetodelta/apache:
+  cumulative_to_delta/apache:
     include:
       metrics:
         - apache.requests.rate
@@ -149,12 +149,12 @@ service:
         - apache
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - metricstransform/apache
-        - cumulativetodelta/apache
+        - cumulative_to_delta/apache
         - deltatorate/apache
         - metricsgeneration/apache
         - transform/desc/apache
@@ -170,10 +170,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/apache
     #   exporters:

--- a/examples/integrations/confluentcloud/config.yaml
+++ b/examples/integrations/confluentcloud/config.yaml
@@ -30,19 +30,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "confluentcloud"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -73,10 +73,10 @@ service:
         - prometheus/confluentcloud
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/confluentcloud
       exporters:

--- a/examples/integrations/docker/config.yaml
+++ b/examples/integrations/docker/config.yaml
@@ -37,7 +37,7 @@ receivers:
       container.cpu.throttling_data.periods:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #  include: # Required parameter
   #  start_at: end
   #  poll_interval: 5s
@@ -109,7 +109,7 @@ service:
     # Optional pipeline
     # logs/docker:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/docker/config.yaml
+++ b/examples/integrations/docker/config.yaml
@@ -54,19 +54,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "docker"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -97,10 +97,10 @@ service:
         - docker_stats
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/docker
       exporters:
@@ -112,10 +112,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/docker 
     #   exporters:

--- a/examples/integrations/elasticsearch/config.yaml
+++ b/examples/integrations/elasticsearch/config.yaml
@@ -169,19 +169,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "elasticsearch"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -198,7 +198,7 @@ processors:
       - include: elasticsearch.node.cluster.io
         action: insert
         new_name: elasticsearch.node.cluster.io.rate
-  cumulativetodelta/elasticsearch:
+  cumulative_to_delta/elasticsearch:
     include:
       metrics:
         - jvm.gc.collections.count.rate
@@ -246,12 +246,12 @@ service:
         - elasticsearch
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - metricstransform/elasticsearch
-        - cumulativetodelta/elasticsearch
+        - cumulative_to_delta/elasticsearch
         - deltatorate/elasticsearch
         - transform/desc/elasticsearch
         - batch
@@ -265,10 +265,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/elasticsearch
     #   exporters:

--- a/examples/integrations/elasticsearch/config.yaml
+++ b/examples/integrations/elasticsearch/config.yaml
@@ -152,7 +152,7 @@ receivers:
       jvm.threads.count:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -187,7 +187,7 @@ processors:
     override: false
     system:
       hostname_sources: ["os"]
-  metricstransform/elasticsearch:
+  metrics_transform/elasticsearch:
     transforms:
       - include: jvm.gc.collections.count
         action: insert
@@ -250,7 +250,7 @@ service:
         - resource_detection/azure
         - resource_detection/gcp
         - resource_detection/system
-        - metricstransform/elasticsearch
+        - metrics_transform/elasticsearch
         - cumulative_to_delta/elasticsearch
         - deltatorate/elasticsearch
         - transform/desc/elasticsearch
@@ -262,7 +262,7 @@ service:
     # Optional pipeline
     # logs/elasticsearch:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/filelog/config.yaml
+++ b/examples/integrations/filelog/config.yaml
@@ -1,5 +1,5 @@
 receivers:
-  filelog:
+  file_log:
     include: # Required parameter
     start_at: # Required parameter
     poll_interval: # Required parameter
@@ -14,7 +14,7 @@ processors:
     check_interval: 1s
     limit_percentage: 50
     spike_limit_percentage: 30
-  solarwinds/filelog:
+  solarwinds/file_log:
     collector_attributes_decoration:
       enabled: true
       extension: solarwinds
@@ -65,9 +65,9 @@ service:
   extensions:
     - solarwinds
   pipelines:
-    logs/filelog:
+    logs/file_log:
       receivers:
-        - filelog
+        - file_log
       processors:
         - memory_limiter
         - resource_detection/ec2
@@ -76,6 +76,6 @@ service:
         - resource_detection/system
         - transform/log_enrichment
         - batch
-        - solarwinds/filelog
+        - solarwinds/file_log
       exporters:
         - otlp_grpc

--- a/examples/integrations/filelog/config.yaml
+++ b/examples/integrations/filelog/config.yaml
@@ -21,19 +21,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "filelog"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -70,10 +70,10 @@ service:
         - filelog
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - transform/log_enrichment
         - batch
         - solarwinds/filelog

--- a/examples/integrations/host/config.yaml
+++ b/examples/integrations/host/config.yaml
@@ -160,20 +160,20 @@ processors:
     check_interval: 1s
     limit_percentage: 50
     spike_limit_percentage: 30
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection: null
-  resourcedetection/system:
+  resource_detection: null
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -349,7 +349,7 @@ processors:
         - include: system.network.io
           binding_attribute: device
   hostvolumes:
-  cumulativetodelta/host:
+  cumulative_to_delta/host:
     include:
       metrics:
         - system.disk.operations.aggregated
@@ -408,7 +408,7 @@ processors:
           - set(description, "Total filesystem size, in bytes.") where name == "system.filesystem.total"
 
   # Adding EC2 tags
-  resourcedetection/tagging-feature:
+  resource_detection/tagging-feature:
     detectors: ["ec2"]
     timeout: 2s
     override: true
@@ -456,17 +456,17 @@ service:
         - host_metrics/processes
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - uuid
-        - resourcedetection/tagging-feature
+        - resource_detection/tagging-feature
         - transform/tagging-feature/host
         - hostinfo/host
         - hostvolumes
         - metricstransform/host
-        - cumulativetodelta/host
+        - cumulative_to_delta/host
         - deltatorate/host
         - transform/desc/host
         - utf8consistency
@@ -481,10 +481,10 @@ service:
 #         - filelog
 #       processors:
 #         - memory_limiter
-#         - resourcedetection/ec2
-#         - resourcedetection/azure
-#         - resourcedetection/gcp
-#         - resourcedetection/system
+#         - resource_detection/ec2
+#         - resource_detection/azure
+#         - resource_detection/gcp
+#         - resource_detection/system
 #         - batch
 #         - solarwinds/host
 #       exporters:

--- a/examples/integrations/host/config.yaml
+++ b/examples/integrations/host/config.yaml
@@ -146,13 +146,13 @@ receivers:
             enabled: true
 
 # Optional receiver for ingesting logs
-#   filelog:
+#   file_log:
 #     include: # Required parameter
 #     start_at: end
 #     poll_interval: 5s
 
 # Optional receiver for ingesting statuses from Windows services (works only on Windows machine)
-#   windowsservice:
+#   windows_service:
 #     collection_interval: 1m
 
 processors:
@@ -193,7 +193,7 @@ processors:
       sw.otelcol.receiver.name: "hostmetrics"
       sw.otelcol.integration.id: # Required parameter
   utf8consistency:
-  metricstransform/host:
+  metrics_transform/host:
     transforms:
       - include: process.cpu.utilization
         action: insert
@@ -422,7 +422,7 @@ processors:
       - replace_all_patterns(resource.attributes, "key", "^ec2.tag.(.*)$", "tags.$1")
 
 # Optional processor for ingesting statuses from Windows services (works only on Windows machine)
-#  attributes/windowsservice:
+#  attributes/windows_service:
 #    actions:
 #      # Renamed generic attribute 'name' to 'service_name' to avoid collision with other receivers.
 #      - key: service_name
@@ -465,7 +465,7 @@ service:
         - transform/tagging-feature/host
         - hostinfo/host
         - hostvolumes
-        - metricstransform/host
+        - metrics_transform/host
         - cumulative_to_delta/host
         - deltatorate/host
         - transform/desc/host
@@ -478,7 +478,7 @@ service:
 #     Optional pipeline for ingesting logs
 #     logs/host:
 #       receivers:
-#         - filelog
+#         - file_log
 #       processors:
 #         - memory_limiter
 #         - resource_detection/ec2
@@ -491,10 +491,10 @@ service:
 #         - otlp_grpc
 
 #     Optional pipeline for ingesting windows service statuses (works only on Windows machine)
-#     windowsservice/host:
+#     windows_service/host:
 #       receivers:
-#         - windowsservice
+#         - windows_service
 #       processors:
-#         - attributes/windowsservice
+#         - attributes/windows_service
 #       exporters:
 #         - otlp_grpc

--- a/examples/integrations/iis/config.yaml
+++ b/examples/integrations/iis/config.yaml
@@ -31,7 +31,7 @@ receivers:
       iis.uptime:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -66,7 +66,7 @@ processors:
     override: false
     system:
       hostname_sources: ["os"]
-  metricstransform/rates/iis:
+  metrics_transform/rates/iis:
     transforms:
       - include: iis.connection.anonymous
         action: insert
@@ -128,7 +128,7 @@ service:
         - resource_detection/azure
         - resource_detection/gcp
         - resource_detection/system
-        - metricstransform/rates/iis
+        - metrics_transform/rates/iis
         - cumulative_to_delta/rates/iis
         - deltatorate/rates/iis
         - transform/desc/iis
@@ -140,7 +140,7 @@ service:
     # Optional pipeline
     # logs/iis:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/iis/config.yaml
+++ b/examples/integrations/iis/config.yaml
@@ -48,19 +48,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "iis"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -77,7 +77,7 @@ processors:
       - include: iis.network.io
         action: insert
         new_name: iis.network.io.rate
-  cumulativetodelta/rates/iis:
+  cumulative_to_delta/rates/iis:
     include:
       metrics:
         - iis.connection.anonymous.rate
@@ -124,12 +124,12 @@ service:
         - iis
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - metricstransform/rates/iis
-        - cumulativetodelta/rates/iis
+        - cumulative_to_delta/rates/iis
         - deltatorate/rates/iis
         - transform/desc/iis
         - batch
@@ -143,10 +143,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/iis
     #   exporters:

--- a/examples/integrations/kafka/config.yaml
+++ b/examples/integrations/kafka/config.yaml
@@ -24,19 +24,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "kafka"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -187,10 +187,10 @@ service:
         - prometheus/kafka
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - metricstransform/kafka
         - filter/kafka
         - transform/desc/kafka
@@ -205,10 +205,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/kafka
     #   exporters:

--- a/examples/integrations/kafka/config.yaml
+++ b/examples/integrations/kafka/config.yaml
@@ -7,7 +7,7 @@ receivers:
           static_configs:
             - targets: # Required parameter
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -42,7 +42,7 @@ processors:
     override: false
     system:
       hostname_sources: ["os"]
-  metricstransform/kafka:
+  metrics_transform/kafka:
     transforms:
       - include: kafka_log_logflushstats_logflushrateandtimems
         match_type: strict
@@ -191,7 +191,7 @@ service:
         - resource_detection/azure
         - resource_detection/gcp
         - resource_detection/system
-        - metricstransform/kafka
+        - metrics_transform/kafka
         - filter/kafka
         - transform/desc/kafka
         - batch
@@ -202,7 +202,7 @@ service:
     # Optional pipeline
     # logs/kafka:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/memcached/config.yaml
+++ b/examples/integrations/memcached/config.yaml
@@ -44,19 +44,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "memcached"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -73,7 +73,7 @@ processors:
       - include: memcached.network
         action: insert
         new_name: memcached.network.rate
-  cumulativetodelta/memcached:
+  cumulative_to_delta/memcached:
     include:
       metrics:
         - memcached.commands.rate
@@ -120,12 +120,12 @@ service:
         - memcached
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - metricstransform/memcached
-        - cumulativetodelta/memcached
+        - cumulative_to_delta/memcached
         - deltatorate/memcached
         - transform/desc/memcached
         - batch
@@ -139,10 +139,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/memcached
     #   exporters:

--- a/examples/integrations/memcached/config.yaml
+++ b/examples/integrations/memcached/config.yaml
@@ -27,7 +27,7 @@ receivers:
       memcached.threads:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -62,7 +62,7 @@ processors:
     override: false
     system:
       hostname_sources: ["os"]
-  metricstransform/memcached:
+  metrics_transform/memcached:
     transforms:
       - include: memcached.commands
         action: insert
@@ -124,7 +124,7 @@ service:
         - resource_detection/azure
         - resource_detection/gcp
         - resource_detection/system
-        - metricstransform/memcached
+        - metrics_transform/memcached
         - cumulative_to_delta/memcached
         - deltatorate/memcached
         - transform/desc/memcached
@@ -136,7 +136,7 @@ service:
     # Optional pipeline
     # logs/memcached:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/mongodb/config.yaml
+++ b/examples/integrations/mongodb/config.yaml
@@ -113,7 +113,7 @@ receivers:
       mongodb.queries.rate:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -185,7 +185,7 @@ service:
     # Optional pipeline
     # logs/mongodb:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/mongodb/config.yaml
+++ b/examples/integrations/mongodb/config.yaml
@@ -130,19 +130,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "mongodb"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -173,10 +173,10 @@ service:
         - mongodb
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/mongodb
       exporters:
@@ -188,10 +188,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/mongodb
     #   exporters:

--- a/examples/integrations/mysql/config.yaml
+++ b/examples/integrations/mysql/config.yaml
@@ -90,7 +90,7 @@ receivers:
       mysql.client.network.io:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -162,7 +162,7 @@ service:
     # Optional pipeline
     # logs/mysql:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/mysql/config.yaml
+++ b/examples/integrations/mysql/config.yaml
@@ -107,19 +107,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "mysql"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -150,10 +150,10 @@ service:
         - mysql
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/mysql
       exporters:
@@ -165,10 +165,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/mysql
     #   exporters:

--- a/examples/integrations/nginx/config.yaml
+++ b/examples/integrations/nginx/config.yaml
@@ -12,7 +12,7 @@ receivers:
       nginx.requests:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -47,7 +47,7 @@ processors:
     override: false
     system:
       hostname_sources: ["os"]
-  metricstransform/nginx:
+  metrics_transform/nginx:
     transforms:
       - include: nginx.connections_accepted
         action: insert
@@ -80,7 +80,7 @@ processors:
         metric1: nginx.connections_accepted.gauge.temp
         metric2: nginx.connections_handled.gauge.temp
         operation: subtract
-  metricstransform/copy_dropped_rate/nginx:
+  metrics_transform/copy_dropped_rate/nginx:
     transforms:
       - include: nginx.connections_dropped
         action: insert
@@ -154,10 +154,10 @@ service:
         - resource_detection/azure
         - resource_detection/gcp
         - resource_detection/system
-        - metricstransform/nginx
+        - metrics_transform/nginx
         - transform/nginx
         - metricsgeneration/nginx
-        - metricstransform/copy_dropped_rate/nginx
+        - metrics_transform/copy_dropped_rate/nginx
         - transform/convert_dropped_rate/nginx
         - cumulative_to_delta/nginx
         - deltatorate/nginx
@@ -171,7 +171,7 @@ service:
     # Optional pipeline
     # logs/nginx:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/nginx/config.yaml
+++ b/examples/integrations/nginx/config.yaml
@@ -29,19 +29,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "nginx"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -90,7 +90,7 @@ processors:
       - context: metric
         statements:
           - convert_gauge_to_sum("cumulative", true) where name == "nginx.connections_dropped.rate"
-  cumulativetodelta/nginx:
+  cumulative_to_delta/nginx:
     include:
       metrics:
         - nginx.connections_accepted.rate
@@ -150,16 +150,16 @@ service:
         - nginx
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - metricstransform/nginx
         - transform/nginx
         - metricsgeneration/nginx
         - metricstransform/copy_dropped_rate/nginx
         - transform/convert_dropped_rate/nginx
-        - cumulativetodelta/nginx
+        - cumulative_to_delta/nginx
         - deltatorate/nginx
         - transform/desc/nginx
         - filter/nginx
@@ -174,10 +174,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/nginx
     #   exporters:

--- a/examples/integrations/oracledb/config.yaml
+++ b/examples/integrations/oracledb/config.yaml
@@ -78,19 +78,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "oracledb"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -121,10 +121,10 @@ service:
         - oracledb
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/oracledb
       exporters:
@@ -136,10 +136,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/oracledb
     #   exporters:

--- a/examples/integrations/oracledb/config.yaml
+++ b/examples/integrations/oracledb/config.yaml
@@ -61,7 +61,7 @@ receivers:
       oracledb.consistent_gets:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -133,7 +133,7 @@ service:
     # Optional pipeline
     # logs/oracledb:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/otlp/config.yaml
+++ b/examples/integrations/otlp/config.yaml
@@ -21,19 +21,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "otlp"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -64,10 +64,10 @@ service:
         - otlp
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/otlp
       exporters:

--- a/examples/integrations/postgresql/config.yaml
+++ b/examples/integrations/postgresql/config.yaml
@@ -93,19 +93,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "postgresql"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -136,10 +136,10 @@ service:
         - postgresql
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/postgresql
       exporters:
@@ -151,10 +151,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/postgresql
     #   exporters:

--- a/examples/integrations/postgresql/config.yaml
+++ b/examples/integrations/postgresql/config.yaml
@@ -76,7 +76,7 @@ receivers:
       postgresql.bgwriter.buffers.writes:
         enabled: true   
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -148,7 +148,7 @@ service:
     # Optional pipeline
     # logs/postgresql:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/prometheus/config.yaml
+++ b/examples/integrations/prometheus/config.yaml
@@ -19,19 +19,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "prometheus"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -62,10 +62,10 @@ service:
         - prometheus
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/prometheus
       exporters:

--- a/examples/integrations/rabbitmq/config.yaml
+++ b/examples/integrations/rabbitmq/config.yaml
@@ -42,19 +42,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "rabbitmq"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -86,10 +86,10 @@ service:
         - prometheus/rabbitmq
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/rabbitmq
       exporters:
@@ -101,10 +101,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/rabbitmq
     #   exporters:

--- a/examples/integrations/rabbitmq/config.yaml
+++ b/examples/integrations/rabbitmq/config.yaml
@@ -25,7 +25,7 @@ receivers:
           static_configs:
             - targets: # Required parameter
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -98,7 +98,7 @@ service:
     # Optional pipeline
     # logs/rabbitmq:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/redis/config.yaml
+++ b/examples/integrations/redis/config.yaml
@@ -82,19 +82,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "redis"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -125,10 +125,10 @@ service:
         - redis
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/redis
       exporters:
@@ -140,10 +140,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/redis
     #   exporters:

--- a/examples/integrations/redis/config.yaml
+++ b/examples/integrations/redis/config.yaml
@@ -65,7 +65,7 @@ receivers:
       redis.role:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -137,7 +137,7 @@ service:
     # Optional pipeline
     # logs/redis:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/snowflake/config.yaml
+++ b/examples/integrations/snowflake/config.yaml
@@ -92,19 +92,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "snowflake"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -135,10 +135,10 @@ service:
         - snowflake
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/snowflake
       exporters:

--- a/examples/integrations/sqlserver/config.yaml
+++ b/examples/integrations/sqlserver/config.yaml
@@ -67,7 +67,7 @@ receivers:
       sqlserver.processes.blocked:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -139,7 +139,7 @@ service:
     # Optional pipeline
     # logs/sqlserver:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/integrations/sqlserver/config.yaml
+++ b/examples/integrations/sqlserver/config.yaml
@@ -84,19 +84,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "sqlserver"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -127,10 +127,10 @@ service:
         - sqlserver
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - batch
         - solarwinds/sqlserver
       exporters:
@@ -142,10 +142,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/sqlserver
     #   exporters:

--- a/examples/integrations/zookeeper/config.yaml
+++ b/examples/integrations/zookeeper/config.yaml
@@ -53,19 +53,19 @@ processors:
     resource:
       sw.otelcol.receiver.name: "zookeeper"
       sw.otelcol.integration.id: # Required parameter
-  resourcedetection/ec2:
+  resource_detection/ec2:
     detectors: ["ec2"]
     timeout: 2s
     override: true
-  resourcedetection/azure:
+  resource_detection/azure:
     detectors: ["azure"]
     timeout: 2s
     override: true
-  resourcedetection/gcp:
+  resource_detection/gcp:
     detectors: ["gcp"]
     timeout: 2s
     override: true
-  resourcedetection/system:
+  resource_detection/system:
     detectors: ["system"]
     timeout: 2s
     override: false
@@ -79,7 +79,7 @@ processors:
       - include: zookeeper.packet.count
         action: insert
         new_name: zookeeper.packet.count.rate
-  cumulativetodelta/zookeeper:
+  cumulative_to_delta/zookeeper:
     include:
       metrics:
         - zookeeper.packet.count.rate
@@ -139,12 +139,12 @@ service:
         - zookeeper
       processors:
         - memory_limiter
-        - resourcedetection/ec2
-        - resourcedetection/azure
-        - resourcedetection/gcp
-        - resourcedetection/system
+        - resource_detection/ec2
+        - resource_detection/azure
+        - resource_detection/gcp
+        - resource_detection/system
         - metricstransform/zookeeper
-        - cumulativetodelta/zookeeper
+        - cumulative_to_delta/zookeeper
         - deltatorate/zookeeper
         - transform/convert_limit/zookeeper
         - metricsgeneration/zookeeper
@@ -161,10 +161,10 @@ service:
     #     - filelog
     #   processors:
     #     - memory_limiter
-    #     - resourcedetection/ec2
-    #     - resourcedetection/azure
-    #     - resourcedetection/gcp
-    #     - resourcedetection/system
+    #     - resource_detection/ec2
+    #     - resource_detection/azure
+    #     - resource_detection/gcp
+    #     - resource_detection/system
     #     - batch
     #     - solarwinds/zookeeper
     #   exporters:

--- a/examples/integrations/zookeeper/config.yaml
+++ b/examples/integrations/zookeeper/config.yaml
@@ -36,7 +36,7 @@ receivers:
       zookeeper.znode.count:
         enabled: true
   # Optional receiver
-  # filelog:
+  # file_log:
   #   include: # Required parameter
   #   start_at: end
   #   poll_interval: 5s
@@ -71,7 +71,7 @@ processors:
     override: false
     system:
       hostname_sources: ["os"]
-  metricstransform/zookeeper:
+  metrics_transform/zookeeper:
     transforms:
       - include: zookeeper.file_descriptor.open
         action: insert
@@ -143,7 +143,7 @@ service:
         - resource_detection/azure
         - resource_detection/gcp
         - resource_detection/system
-        - metricstransform/zookeeper
+        - metrics_transform/zookeeper
         - cumulative_to_delta/zookeeper
         - deltatorate/zookeeper
         - transform/convert_limit/zookeeper
@@ -158,7 +158,7 @@ service:
     # Optional pipeline
     # logs/zookeeper:
     #   receivers:
-    #     - filelog
+    #     - file_log
     #   processors:
     #     - memory_limiter
     #     - resource_detection/ec2

--- a/examples/tail-sampling/collector.load-balancing.yaml
+++ b/examples/tail-sampling/collector.load-balancing.yaml
@@ -22,7 +22,7 @@ exporters:
   # resiliency options available:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/loadbalancingexporter/README.md
   # Note currently only OTLP/gRPC is supported https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19185.
-  loadbalancing:
+  load_balancing:
     routing_key: "traceID"
     protocol:
       otlp:
@@ -61,7 +61,7 @@ service:
     traces:
       receivers: [otlp/notls]
       processors: [memory_limiter]
-      exporters: [loadbalancing] # [debug, loadbalancing] for debugging.
+      exporters: [load_balancing] # [debug, load_balancing] for debugging.
     logs:
       receivers: [otlp/notls]
       processors: [memory_limiter, solarwinds/otlp]


### PR DESCRIPTION
#### Description
Bumps the referenced OpenTelemetry Collector version to **v0.157.0** and updates every example config to the current upstream snake_case component-type names.

**Scope:**
- `Makefile`: `otel_version` v0.152.0 → v0.157.0.
- `CHANGELOG.md`: one `vNext` entry — `Updates OpenTelemetry modules to [v1.63.0/v0.157.0](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.157.0)` — matching the format used by v0.150.0 and v0.152.0 bumps.
- **Example configs — deprecated camelCase types renamed to snake_case** per upstream contrib normalization. Old aliases still resolve at runtime, but will be removed in a future contrib release:
  - `resourcedetection` → `resource_detection` (deprecated in v0.153.0)
  - `cumulativetodelta` → `cumulative_to_delta` (deprecated in v0.157.0)
  - `loadbalancing` → `load_balancing` (deprecated in v0.157.0)
  - `metricstransform` → `metrics_transform`
  - `filelog` → `file_log`
  - `windowsservice` → `windows_service`

  Only the component-type prefix is renamed. Instance suffixes (`/ec2`, `/host`, `/rates`, …) and everything else (attribute values, comments describing the exporters) is preserved.

**Modified files (24):**
- `Makefile`, `CHANGELOG.md`
- `examples/integrations/{apache,confluentcloud,docker,elasticsearch,filelog,host,iis,kafka,memcached,mongodb,mysql,nginx,oracledb,otlp,postgresql,prometheus,rabbitmq,redis,snowflake,sqlserver,zookeeper}/config.yaml`
- `examples/tail-sampling/collector.load-balancing.yaml`

**No breaking changes** — repo is examples/docs only, no Go modules, no distribution artifacts. Old alias names still work at runtime; renames are pre-emptive to keep example configs current with upstream conventions.

**Tracking Issue:** [NH-141753](https://swicloud.atlassian.net/browse/NH-141753)

#### Testing
- No Go code changes — no test suite to run.
- Manual validation against v0.157 collector binary built from the private-releases counterpart PR (`solarwinds-cloud/solarwinds-otel-collector-releases#405`): host integration example loaded end-to-end, ingested telemetry, `Host` + `SolarwindsOtelCollector` entities created on the SWO dev endpoint. No config-parse errors on the renamed keys.


[NH-141753]: https://swicloud.atlassian.net/browse/NH-141753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ